### PR TITLE
removed bot trigger of bot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -696,7 +696,6 @@ class AircBot(irc.bot.SingleServerIRCBot):
             rf'\b{re.escape(current_nick)}\b',  # Current nick with word boundaries
             rf'\b{re.escape(self.config.IRC_NICKNAME.lower())}\b',  # Original configured name
             r'\baircbot\b',  # Bot name with word boundaries
-            r'\bbot\b',  # Generic bot reference with word boundaries
         ]
         
         # Check if any of the patterns appear in the message
@@ -725,7 +724,7 @@ class AircBot(irc.bot.SingleServerIRCBot):
         
         # Remove bot name mentions to get the actual question/comment
         clean_message = message
-        for pattern in [current_nick, self.config.IRC_NICKNAME.lower(), "aircbot", "bot"]:
+        for pattern in [current_nick, self.config.IRC_NICKNAME.lower(), "aircbot"]:
             clean_message = clean_message.replace(pattern, "").replace(pattern.title(), "")
         
         # Clean up punctuation and whitespace

--- a/bot.py
+++ b/bot.py
@@ -724,8 +724,9 @@ class AircBot(irc.bot.SingleServerIRCBot):
         
         # Remove bot name mentions to get the actual question/comment
         clean_message = message
-        for pattern in [current_nick, self.config.IRC_NICKNAME.lower(), "aircbot"]:
-            clean_message = clean_message.replace(pattern, "").replace(pattern.title(), "")
+        mention_patterns = [current_nick, self.config.IRC_NICKNAME.lower(), "aircbot"]
+        mention_regex = re.compile(rf'\b(?:{"|".join(map(re.escape, mention_patterns))})\b', re.IGNORECASE)
+        clean_message = mention_regex.sub("", clean_message)
         
         # Clean up punctuation and whitespace
         clean_message = clean_message.strip(" ,:;!?")

--- a/test_suite.py
+++ b/test_suite.py
@@ -53,7 +53,6 @@ def is_bot_mentioned(message: str, bot_nick: str = "bubba") -> bool:
     mention_patterns = [
         rf'\b{re.escape(bot_nick.lower())}\b',
         r'\baircbot\b',
-        r'\bbot\b',
     ]
     
     for pattern in mention_patterns:
@@ -68,12 +67,12 @@ def test_mention_detection():
     test_cases = [
         ("Hey bubba, what's the weather?", True),
         ("bubba can you help me?", True),
-        ("I think the bot is broken", True),
+        ("I think the bot is broken", False),
         ("aircbot please explain this", True),
         ("Just chatting with friends", False),
         ("BUBBA: what time is it?", True),
         ("Is the AircBot working?", True),
-        ("Bot, tell me a joke", True),
+        ("Bot, tell me a joke", False),
         ("This is just a normal message", False),
         ("The robot is cool", False),
     ]


### PR DESCRIPTION
This pull request removes the generic "bot" keyword from the bot mention detection logic in both the main application (`bot.py`) and its corresponding test suite (`test_suite.py`). This change ensures that the bot is only triggered by more specific keywords or names, reducing false positives.

### Changes to bot mention detection:

* [`bot.py`](diffhunk://#diff-36f6200cd8353111badb874140eba3af6055f4cc5839fbdeb9ede992620828c1L699): Removed the generic `\bbot\b` pattern from the list of mention detection patterns in `is_bot_mentioned` and updated the `handle_name_mention` method to exclude "bot" from the cleanup logic. [[1]](diffhunk://#diff-36f6200cd8353111badb874140eba3af6055f4cc5839fbdeb9ede992620828c1L699) [[2]](diffhunk://#diff-36f6200cd8353111badb874140eba3af6055f4cc5839fbdeb9ede992620828c1L728-R727)

### Updates to test cases:

* [`test_suite.py`](diffhunk://#diff-914905ecb2259059cf76beab2fcb8a41aecadb6a81f3a09316daca05f5c29ed8L56): Removed the `\bbot\b` pattern from the mention detection logic in `is_bot_mentioned`. Updated test cases in `test_mention_detection` to reflect the removal of the "bot" keyword, ensuring that phrases like "I think the bot is broken" and "Bot, tell me a joke" no longer trigger a match. [[1]](diffhunk://#diff-914905ecb2259059cf76beab2fcb8a41aecadb6a81f3a09316daca05f5c29ed8L56) [[2]](diffhunk://#diff-914905ecb2259059cf76beab2fcb8a41aecadb6a81f3a09316daca05f5c29ed8L71-R75)