### PR TITLE
fixed links not working in private

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -10,7 +10,6 @@ import irc.connection
 import ssl
 import logging
 import sys
-import re
 from threading import Thread
 import time
 

--- a/bot.py
+++ b/bot.py
@@ -10,6 +10,7 @@ import irc.connection
 import ssl
 import logging
 import sys
+import re
 from threading import Thread
 import time
 
@@ -82,8 +83,6 @@ class AircBot(irc.bot.SingleServerIRCBot):
         
         if nick == self.config.IRC_NICKNAME:
             logger.info(f"Successfully joined {channel}")
-            # Send a greeting message
-            connection.privmsg(channel, "🤖 AircBot is online!")
     
     def on_pubmsg(self, connection, event):
         """Called when a public message is received in a channel"""
@@ -171,6 +170,12 @@ class AircBot(irc.bot.SingleServerIRCBot):
         except Exception as e:
             logger.error(f"Error in private conversation with {user}: {e}")
             connection.privmsg(user, "❌ Something went wrong. Please try again later.")
+    
+    def _should_use_private_message(self, is_private):
+        """Determine if we should use private messaging for links commands"""
+        # If the command is already in a private message, don't switch to private
+        # If the command is in a channel and private messaging is enabled, use private
+        return self.config.LINKS_USE_PRIVATE_MSG and not is_private
     
     def handle_command(self, connection, channel, user, message, is_private=False):
         """Handle bot commands with rate limiting"""
@@ -310,18 +315,22 @@ class AircBot(irc.bot.SingleServerIRCBot):
     def show_recent_links(self, connection, channel, requesting_user=None):
         """Show recent links in the channel"""
         # If requesting_user is provided, we're sending to them privately about a channel
-        source_channel = channel if not requesting_user else self.config.IRC_CHANNEL
+        # If channel is a user (private message), always use the configured IRC channel
+        if requesting_user or channel == requesting_user or not channel.startswith('#'):
+            source_channel = self.config.IRC_CHANNEL
+        else:
+            source_channel = channel
         links = self.db.get_recent_links(source_channel, limit=5)
         
         if not links:
             msg = "No links saved yet!"
-            if requesting_user:
+            if requesting_user or not channel.startswith('#'):
                 msg = f"No links saved in {source_channel} yet!"
             connection.privmsg(channel, msg)
             return
         
         intro_msg = "📚 Recent links:"
-        if requesting_user:
+        if requesting_user or not channel.startswith('#'):
             intro_msg = f"📚 Recent links from {source_channel}:"
         connection.privmsg(channel, intro_msg)
         for link in links:
@@ -333,18 +342,22 @@ class AircBot(irc.bot.SingleServerIRCBot):
     def search_links(self, connection, channel, query, requesting_user=None):
         """Search for links matching a query"""
         # If requesting_user is provided, we're sending to them privately about a channel
-        source_channel = channel if not requesting_user else self.config.IRC_CHANNEL
+        # If channel is a user (private message), always use the configured IRC channel
+        if requesting_user or channel == requesting_user or not channel.startswith('#'):
+            source_channel = self.config.IRC_CHANNEL
+        else:
+            source_channel = channel
         links = self.db.search_links(source_channel, query, limit=3)
         
         if not links:
             msg = f"No links found matching '{query}'"
-            if requesting_user:
+            if requesting_user or not channel.startswith('#'):
                 msg = f"No links found in {source_channel} matching '{query}'"
             connection.privmsg(channel, msg)
             return
         
         intro_msg = f"🔍 Search results for '{query}':"
-        if requesting_user:
+        if requesting_user or not channel.startswith('#'):
             intro_msg = f"🔍 Search results from {source_channel} for '{query}':"
         connection.privmsg(channel, intro_msg)
         for link in links:
@@ -356,11 +369,15 @@ class AircBot(irc.bot.SingleServerIRCBot):
     def show_stats(self, connection, channel, requesting_user=None):
         """Show link statistics"""
         # If requesting_user is provided, we're sending to them privately about a channel
-        source_channel = channel if not requesting_user else self.config.IRC_CHANNEL
+        # If channel is a user (private message), always use the configured IRC channel
+        if requesting_user or channel == requesting_user or not channel.startswith('#'):
+            source_channel = self.config.IRC_CHANNEL
+        else:
+            source_channel = channel
         stats = self.db.get_link_stats(source_channel)
         
         msg = f"📊 Stats"
-        if requesting_user:
+        if requesting_user or not channel.startswith('#'):
             msg += f" for {source_channel}"
         msg += f": {stats.get('total_links', 0)} links saved by {stats.get('unique_users', 0)} users"
         if 'top_contributor' in stats:
@@ -508,18 +525,22 @@ class AircBot(irc.bot.SingleServerIRCBot):
     def show_detailed_links(self, connection, channel, requesting_user=None):
         """Show recent links with detailed information (user, timestamp)"""
         # If requesting_user is provided, we're sending to them privately about a channel
-        source_channel = channel if not requesting_user else self.config.IRC_CHANNEL
+        # If channel is a user (private message), always use the configured IRC channel
+        if requesting_user or channel == requesting_user or not channel.startswith('#'):
+            source_channel = self.config.IRC_CHANNEL
+        else:
+            source_channel = channel
         links = self.db.get_links_with_details(source_channel, limit=5)
         
         if not links:
             msg = "No links saved yet!"
-            if requesting_user:
+            if requesting_user or not channel.startswith('#'):
                 msg = f"No links saved in {source_channel} yet!"
             connection.privmsg(channel, msg)
             return
         
         intro_msg = "📚 Recent links (with details):"
-        if requesting_user:
+        if requesting_user or not channel.startswith('#'):
             intro_msg = f"📚 Recent links from {source_channel} (with details):"
         connection.privmsg(channel, intro_msg)
         for link in links:
@@ -539,18 +560,22 @@ class AircBot(irc.bot.SingleServerIRCBot):
     def show_links_by_user(self, connection, channel, username, requesting_user=None):
         """Show all links shared by a specific user"""
         # If requesting_user is provided, we're sending to them privately about a channel
-        source_channel = channel if not requesting_user else self.config.IRC_CHANNEL
+        # If channel is a user (private message), always use the configured IRC channel
+        if requesting_user or channel == requesting_user or not channel.startswith('#'):
+            source_channel = self.config.IRC_CHANNEL
+        else:
+            source_channel = channel
         links = self.db.get_all_links_by_user(source_channel, username)
         
         if not links:
             msg = f"No links found from user '{username}'"
-            if requesting_user:
+            if requesting_user or not channel.startswith('#'):
                 msg += f" in {source_channel}"
             connection.privmsg(channel, msg)
             return
         
         intro_msg = f"🔍 Links shared by {username}:"
-        if requesting_user:
+        if requesting_user or not channel.startswith('#'):
             intro_msg = f"🔍 Links shared by {username} in {source_channel}:"
         connection.privmsg(channel, intro_msg)
         for link in links[:3]:  # Limit to 3 to avoid spam


### PR DESCRIPTION
This pull request refines the behavior of the bot's link-related commands to better handle private messages and introduces a utility method to centralize logic for determining when to use private messaging. Additionally, it removes a redundant greeting message and imports a new module for potential future use.

### Enhancements to private messaging logic:
* Added a `_should_use_private_message` method to centralize the logic for determining whether to use private messaging for link-related commands. This improves maintainability and readability.
* Updated methods like `show_recent_links`, `search_links`, `show_stats`, `show_detailed_links`, and `show_links_by_user` to handle private messages more consistently. If the channel is a private message or a user, the bot now defaults to using the configured IRC channel for link-related operations. [[1]](diffhunk://#diff-36f6200cd8353111badb874140eba3af6055f4cc5839fbdeb9ede992620828c1L313-R333) [[2]](diffhunk://#diff-36f6200cd8353111badb874140eba3af6055f4cc5839fbdeb9ede992620828c1L336-R360) [[3]](diffhunk://#diff-36f6200cd8353111badb874140eba3af6055f4cc5839fbdeb9ede992620828c1L359-R380) [[4]](diffhunk://#diff-36f6200cd8353111badb874140eba3af6055f4cc5839fbdeb9ede992620828c1L511-R543) [[5]](diffhunk://#diff-36f6200cd8353111badb874140eba3af6055f4cc5839fbdeb9ede992620828c1L542-R578)

### Code cleanup:
* Removed a redundant greeting message that was sent upon joining a channel to reduce noise.

### Preparatory changes:
* Added an import for the `re` module, likely for future use or planned enhancements.