### PR TITLE
added configs to !links command to adjust number responses and search limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,12 @@ See `personality_prompt.txt.example` for a sample personality configuration.
 - `RATE_LIMIT_USER_PER_MINUTE` - Max requests per user per minute (default: 1)
 - `RATE_LIMIT_TOTAL_PER_MINUTE` - Max total requests per minute (default: 10)
 
+### Link Display Limits
+- `LINKS_RECENT_LIMIT` - Number of links shown by `!links` command (default: 5)
+- `LINKS_SEARCH_LIMIT` - Number of links shown by `!links search` command (default: 3)
+- `LINKS_DETAILS_LIMIT` - Number of links shown by `!links details` command (default: 5)
+- `LINKS_BY_USER_LIMIT` - Number of links shown by `!links by <user>` command (default: 3)
+
 ### Privacy Protection
 - `PRIVACY_FILTER_ENABLED` - Enable privacy filtering for LLM context (default: true)
 - `PRIVACY_CHANNEL_SIZE_THRESHOLD` - Max channel size for full privacy filtering (default: 50)

--- a/bot.py
+++ b/bot.py
@@ -360,7 +360,7 @@ class AircBot(irc.bot.SingleServerIRCBot):
         """Show recent links in the channel"""
         source_channel = self._get_source_channel(channel, requesting_user)
         is_private_context = self._is_private_context(channel, requesting_user)
-        links = self.db.get_recent_links(source_channel, limit=5)
+        links = self.db.get_recent_links(source_channel, limit=self.config.LINKS_RECENT_LIMIT)
         
         if not links:
             msg = "No links saved yet!"
@@ -383,7 +383,7 @@ class AircBot(irc.bot.SingleServerIRCBot):
         """Search for links matching a query"""
         source_channel = self._get_source_channel(channel, requesting_user)
         is_private_context = self._is_private_context(channel, requesting_user)
-        links = self.db.search_links(source_channel, query, limit=3)
+        links = self.db.search_links(source_channel, query, limit=self.config.LINKS_SEARCH_LIMIT)
         
         if not links:
             msg = f"No links found matching '{query}'"
@@ -562,7 +562,7 @@ class AircBot(irc.bot.SingleServerIRCBot):
         """Show recent links with detailed information (user, timestamp)"""
         source_channel = self._get_source_channel(channel, requesting_user)
         is_private_context = self._is_private_context(channel, requesting_user)
-        links = self.db.get_links_with_details(source_channel, limit=5)
+        links = self.db.get_links_with_details(source_channel, limit=self.config.LINKS_DETAILS_LIMIT)
         
         if not links:
             msg = "No links saved yet!"
@@ -606,7 +606,7 @@ class AircBot(irc.bot.SingleServerIRCBot):
         if is_private_context:
             intro_msg = f"🔍 Links shared by {username} in {source_channel}:"
         connection.privmsg(channel, intro_msg)
-        for link in links[:3]:  # Limit to 3 to avoid spam
+        for link in links[:self.config.LINKS_BY_USER_LIMIT]:  # Limit to avoid spam
             msg = f"• {link['title']} | 🕐 {link['formatted_time']} | 🔗 {link['url']}"
             if len(msg) > 400:
                 connection.privmsg(channel, f"• {link['title']}")
@@ -614,8 +614,8 @@ class AircBot(irc.bot.SingleServerIRCBot):
             else:
                 connection.privmsg(channel, msg)
         
-        if len(links) > 3:
-            connection.privmsg(channel, f"... and {len(links) - 3} more links")
+        if len(links) > self.config.LINKS_BY_USER_LIMIT:
+            connection.privmsg(channel, f"... and {len(links) - self.config.LINKS_BY_USER_LIMIT} more links")
     
     def handle_ask_command(self, connection, channel, user, question, show_thinking=True):
         """Handle !ask command - query the LLM with optional context"""

--- a/config.py
+++ b/config.py
@@ -55,6 +55,12 @@ class Config:
     # Bot behavior
     COMMAND_PREFIX = '!'
     
+    # Link display limits
+    LINKS_RECENT_LIMIT = int(os.getenv('LINKS_RECENT_LIMIT', '5'))  # Default: 5 links for !links
+    LINKS_SEARCH_LIMIT = int(os.getenv('LINKS_SEARCH_LIMIT', '3'))  # Default: 3 links for !links search
+    LINKS_DETAILS_LIMIT = int(os.getenv('LINKS_DETAILS_LIMIT', '5'))  # Default: 5 links for !links details
+    LINKS_BY_USER_LIMIT = int(os.getenv('LINKS_BY_USER_LIMIT', '3'))  # Default: 3 links for !links by user
+    
     # Private messaging settings
     PRIVATE_MSG_ENABLED = os.getenv('PRIVATE_MSG_ENABLED', 'true').lower() == 'true'
     LINKS_USE_PRIVATE_MSG = os.getenv('LINKS_USE_PRIVATE_MSG', 'true').lower() == 'true'

--- a/simple_discord_bot.py
+++ b/simple_discord_bot.py
@@ -133,7 +133,7 @@ class SimpleDiscordBot(discord.Client):
         
         if not args:
             # Show recent links
-            links = self.db.get_recent_links(channel_name, limit=5)
+            links = self.db.get_recent_links(channel_name, limit=self.config.LINKS_RECENT_LIMIT)
             if not links:
                 await message.channel.send("No links saved yet!")
                 return
@@ -149,7 +149,7 @@ class SimpleDiscordBot(discord.Client):
         
         elif args[0] == "search" and len(args) > 1:
             query = ' '.join(args[1:])
-            links = self.db.search_links(channel_name, query, limit=3)
+            links = self.db.search_links(channel_name, query, limit=self.config.LINKS_SEARCH_LIMIT)
             if not links:
                 await message.channel.send(f"No links found matching '{query}'")
                 return


### PR DESCRIPTION
This pull request introduces configurable limits for link display commands in both IRC and Discord bots. The changes centralize these limits into the `Config` class, allowing them to be easily adjusted via environment variables. The updates ensure consistency across the application and improve maintainability.

### Configuration Updates:
* Added new configuration options in `config.py` to define link display limits: `LINKS_RECENT_LIMIT`, `LINKS_SEARCH_LIMIT`, `LINKS_DETAILS_LIMIT`, and `LINKS_BY_USER_LIMIT`. These limits are now configurable via environment variables.

### Bot Command Updates:
* Updated the `!links` command in `bot.py` to use `LINKS_RECENT_LIMIT` for recent links, ensuring the limit is configurable.
* Updated the `!links search` command in `bot.py` to use `LINKS_SEARCH_LIMIT` for search results, aligning it with the new configuration.
* Updated the `!links details` command in `bot.py` to use `LINKS_DETAILS_LIMIT` for detailed link displays.
* Updated the `!links by <user>` command in `bot.py` to use `LINKS_BY_USER_LIMIT` for user-specific link displays and adjusted the message for additional links accordingly.

### Discord Bot Updates:
* Modified the `handle_links_command` method in `simple_discord_bot.py` to use `LINKS_RECENT_LIMIT` for recent links and `LINKS_SEARCH_LIMIT` for search results, ensuring consistency with the IRC bot. [[1]](diffhunk://#diff-b108c94d345d73cfb74112c2ed71db0fc49411b98e359b6604ae55f8cf299bd6L136-R136) [[2]](diffhunk://#diff-b108c94d345d73cfb74112c2ed71db0fc49411b98e359b6604ae55f8cf299bd6L152-R152)

### Documentation Updates:
* Added a new section in `README.md` to document the link display limit configuration options.